### PR TITLE
fix llama-cpp-python[server] issues

### DIFF
--- a/llama_cpp/llama_chat_format.py
+++ b/llama_cpp/llama_chat_format.py
@@ -594,7 +594,8 @@ def chat_formatter_to_chat_completion_handler(
             tool_choice=tool_choice,
         )
         prompt = llama.tokenize(
-            result.prompt.encode("utf-8"),
+            vocab=llama.llama_model_get_vocab(model),
+            text=result.prompt.encode("utf-8"),
             add_bos=not result.added_special,
             special=True,
         )


### PR DESCRIPTION
After testing on llama-cpp-server[python]
I noticed such issue below:

```
Exception: Llama.tokenize() missing 1 required positional argument: 'text'
Traceback (most recent call last):
  File "/opt/homebrew/Caskroom/miniconda/base/envs/llama/lib/python3.10/site-packages/llama_cpp/server/errors.py", line 173, in custom_route_handler
    response = await original_route_handler(request)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/llama/lib/python3.10/site-packages/fastapi/routing.py", line 301, in app
    raw_response = await run_endpoint_function(
  File "/opt/homebrew/Caskroom/miniconda/base/envs/llama/lib/python3.10/site-packages/fastapi/routing.py", line 212, in run_endpoint_function
    return await dependant.call(**values)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/llama/lib/python3.10/site-packages/llama_cpp/server/app.py", line 526, in create_chat_completion
    return await run_in_threadpool(llama.create_chat_completion, **kwargs)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/llama/lib/python3.10/site-packages/starlette/concurrency.py", line 39, in run_in_threadpool
    return await anyio.to_thread.run_sync(func, *args)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/llama/lib/python3.10/site-packages/anyio/to_thread.py", line 56, in run_sync
    return await get_async_backend().run_sync_in_worker_thread(
  File "/opt/homebrew/Caskroom/miniconda/base/envs/llama/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 2441, in run_sync_in_worker_thread
    return await future
  File "/opt/homebrew/Caskroom/miniconda/base/envs/llama/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 943, in run
    result = context.run(func, *args)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/llama/lib/python3.10/site-packages/llama_cpp/llama.py", line 2011, in create_chat_completion
    return handler(
  File "/opt/homebrew/Caskroom/miniconda/base/envs/llama/lib/python3.10/site-packages/llama_cpp/llama_chat_format.py", line 596, in chat_completion_handler
    prompt = llama.tokenize(
TypeError: Llama.tokenize() missing 1 required positional argument: 'text'
```

After the PR the issue is gone and the llama-cpp-python[server] working as expected