### PR TITLE
Add GitHub Actions workflows for CUDA 12.1 wheel            builds

### DIFF
--- a/.github/workflows/build-wheels-cu121-linux-basic.yml
+++ b/.github/workflows/build-wheels-cu121-linux-basic.yml
@@ -1,0 +1,96 @@
+name: Build Wheels(CU121) for Linux(Basic)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build_wheels:
+    name: Build Wheel ${{ matrix.os }} ${{ matrix.pyver }} ${{ matrix.cuda }} ${{ matrix.releasetag == 'wheels' && 'AVX2' || matrix.releasetag }}
+    runs-on: ubuntu-22.04
+    container: nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04
+    strategy:
+      matrix:
+        os: ["ubuntu-22.04"]
+        pyver: ["3.10", "3.11", "3.12", "3.13"]
+        cuda: ["12.1.1"]
+        releasetag: ["Basic"]
+        cudaarch: ["all"]
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      CUDAVER: ${{ matrix.cuda }}
+      AVXVER: ${{ matrix.releasetag }}
+      CUDAARCHVER: ${{ matrix.cudaarch }}
+
+    steps:
+      - name: Install dependencies
+        run: |
+            apt update
+            apt install -y build-essential ccache cmake curl git libgomp1 libjpeg-dev libssl-dev
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - name: Install the latest version of uv and set the python version
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ matrix.pyver }}
+          activate-environment: true
+          enable-cache: true
+
+      - run: nvcc -V
+
+      - name: Build Wheel With Cmake
+        env:
+          LD_LIBRARY_PATH: "/usr/local/cuda/lib64:/usr/local/cuda/compat:/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH}"
+          VERBOSE: 1
+          CUDA_HOME: "/usr/local/cuda/"
+          CUDA_PATH: "${PATH}"
+          CUDA_TOOLKIT_ROOT_DIR: "/usr/local/cuda/"
+        run: |
+          echo "VERBOSE=1" >> $GITHUB_ENV
+          find /usr/ -name 'libcuda.so.*'
+          echo $LD_LIBRARY_PATH
+
+          # CUDA 12.1 supports up to compute capability 90 (Hopper)
+          CMAKE_ARGS="-DGGML_CUDA=on -DCMAKE_CUDA_ARCHITECTURES='70-real;75-real;80-real;86-real;87-real;89-real;90-real'"
+          CMAKE_ARGS="-DGGML_CUDA_FORCE_MMQ=on ${CMAKE_ARGS}"
+          CMAKE_ARGS="${CMAKE_ARGS} -DLLAMA_CURL=off -DLLAMA_OPENSSL=on -DLLAMA_HTTPLIB=on"
+
+          # Basic options for compiling without AVX instructions
+          if [ "${AVXVER}" = "Basic" ]; then
+            CMAKE_ARGS="${CMAKE_ARGS} -DGGML_AVX=off -DGGML_AVX2=off -DGGML_AVX512=off -DGGML_FMA=off -DGGML_F16C=off"
+          fi
+
+          echo ${CMAKE_ARGS}
+          echo "CMAKE_ARGS=${CMAKE_ARGS}" >> $GITHUB_ENV
+
+          uv pip install build setuptools wheel packaging
+          CMAKE_ARGS=${CMAKE_ARGS} uv build --wheel
+
+          wheel_file=$(ls dist/*.whl | head -n 1)
+          tag_ver=$(basename "$wheel_file" | cut -d'-' -f 2)
+          echo "TAG_VERSION=$tag_ver" >> $GITHUB_ENV
+
+          cuda_ver_short=$(echo "${CUDAVER}" | cut -d'.' -f 1,2 | sed 's/\.//g')
+          echo "CUDA_VERSION=$cuda_ver_short" >> $GITHUB_ENV
+
+      - name: Get Current Date
+        id: get-date
+        run: |
+          currentDate=$(date +%Y%m%d)
+          echo "BUILD_DATE=$currentDate" >> $GITHUB_ENV
+
+      - uses: softprops/action-gh-release@v2.2.2
+        with:
+          files: dist/*
+          tag_name: v${{ env.TAG_VERSION }}-cu${{ env.CUDA_VERSION }}-${{ env.AVXVER }}-linux-${{ env.BUILD_DATE }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-wheels-cu121-linux.yml
+++ b/.github/workflows/build-wheels-cu121-linux.yml
@@ -1,0 +1,104 @@
+name: Build Wheels(CU121) for Linux
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build_wheels:
+    name: Build Wheel ${{ matrix.os }} ${{ matrix.pyver }} ${{ matrix.cuda }} ${{ matrix.releasetag == 'wheels' && 'AVX2' || matrix.releasetag }}
+    runs-on: ubuntu-22.04
+    container: nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04
+    strategy:
+      matrix:
+        os: ["ubuntu-22.04"]
+        pyver: ["3.10", "3.11", "3.12", "3.13"]
+        cuda: ["12.1.1"]
+        releasetag: ["AVX2"]
+        cudaarch: ["all"]
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      CUDAVER: ${{ matrix.cuda }}
+      AVXVER: ${{ matrix.releasetag }}
+      CUDAARCHVER: ${{ matrix.cudaarch }}
+
+    steps:
+      - name: Install dependencies
+        run: |
+            apt update
+            apt install -y build-essential ccache cmake curl git libgomp1 libjpeg-dev libssl-dev
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - name: Install the latest version of uv and set the python version
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ matrix.pyver }}
+          activate-environment: true
+          enable-cache: true
+
+      - run: nvcc -V
+
+      - name: Build Wheel With Cmake
+        env:
+          LD_LIBRARY_PATH: "/usr/local/cuda/lib64:/usr/local/cuda/compat:/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH}"
+          VERBOSE: 1
+          CUDA_HOME: "/usr/local/cuda/"
+          CUDA_PATH: "${PATH}"
+          CUDA_TOOLKIT_ROOT_DIR: "/usr/local/cuda/"
+        run: |
+          echo "VERBOSE=1" >> $GITHUB_ENV
+          find /usr/ -name 'libcuda.so.*'
+          echo $LD_LIBRARY_PATH
+
+          # CUDA 12.1 supports up to compute capability 90 (Hopper)
+          CMAKE_ARGS="-DGGML_CUDA=on -DCMAKE_CUDA_ARCHITECTURES='70-real;75-real;80-real;86-real;87-real;89-real;90-real'"
+          CMAKE_ARGS="-DGGML_CUDA_FORCE_MMQ=on ${CMAKE_ARGS}"
+          CMAKE_ARGS="${CMAKE_ARGS} -DLLAMA_CURL=off -DLLAMA_OPENSSL=on -DLLAMA_HTTPLIB=on"
+
+          if [ "${AVXVER}" = "AVX" ]; then
+            CMAKE_ARGS="${CMAKE_ARGS} -DGGML_AVX=on -DGGML_AVX2=off -DGGML_AVX512=off -DGGML_FMA=off -DGGML_F16C=off"
+          fi
+          if [ "${AVXVER}" = "AVX2" ]; then
+            CMAKE_ARGS="${CMAKE_ARGS} -DGGML_AVX=on -DGGML_AVX2=on -DGGML_AVX512=off"
+          fi
+          if [ "${AVXVER}" = "AVXVNNI" ]; then
+            CMAKE_ARGS="${CMAKE_ARGS} -DGGML_AVX=on -DGGML_AVX2=on -DGGML_AVX_VNNI=on"
+          fi
+          if [ "${AVXVER}" = "Basic" ]; then
+            CMAKE_ARGS="${CMAKE_ARGS} -DGGML_AVX=off -DGGML_AVX2=off -DGGML_AVX512=off -DGGML_FMA=off -DGGML_F16C=off"
+          fi
+
+          echo ${CMAKE_ARGS}
+          echo "CMAKE_ARGS=${CMAKE_ARGS}" >> $GITHUB_ENV
+
+          uv pip install build setuptools wheel packaging
+          CMAKE_ARGS=${CMAKE_ARGS} uv build --wheel
+
+          wheel_file=$(ls dist/*.whl | head -n 1)
+          tag_ver=$(basename "$wheel_file" | cut -d'-' -f 2)
+          echo "TAG_VERSION=$tag_ver" >> $GITHUB_ENV
+
+          cuda_ver_short=$(echo "${CUDAVER}" | cut -d'.' -f 1,2 | sed 's/\.//g')
+          echo "CUDA_VERSION=$cuda_ver_short" >> $GITHUB_ENV
+
+      - name: Get Current Date
+        id: get-date
+        run: |
+          currentDate=$(date +%Y%m%d)
+          echo "BUILD_DATE=$currentDate" >> $GITHUB_ENV
+
+      - uses: softprops/action-gh-release@v2.2.2
+        with:
+          files: dist/*
+          tag_name: v${{ env.TAG_VERSION }}-cu${{ env.CUDA_VERSION }}-${{ env.AVXVER }}-linux-${{ env.BUILD_DATE }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-wheels-cu121-win-basic.yml
+++ b/.github/workflows/build-wheels-cu121-win-basic.yml
@@ -1,0 +1,100 @@
+name: Build Wheels (CU121) for Windows(Basic)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build_wheels:
+    name: Build Wheel ${{ matrix.os }} ${{ matrix.pyver }} ${{ matrix.cuda }} ${{ matrix.releasetag }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['windows-2019']  # CUDA 12.1 requires older MSVC (< 14.40)
+        pyver: ["3.10", "3.11", "3.12", "3.13"]
+        cuda: ["12.1.1"]
+        releasetag: ["Basic"]
+        cudaarch: ["all"]
+    defaults:
+      run:
+        shell: pwsh
+    env:
+      CUDAVER: ${{ matrix.cuda }}
+      AVXVER: ${{ matrix.releasetag }}
+      CUDAARCHVER: ${{ matrix.cudaarch }}
+      MAX_JOBS: 8
+
+    steps:
+      - name: Add MSBuild to PATH
+        if: runner.os == 'Windows'
+        uses: microsoft/setup-msbuild@v2
+        with:
+          msbuild-architecture: x64
+
+      - uses: actions/checkout@v5
+        with:
+          submodules: "recursive"
+
+      - name: Install CUDA ${{ matrix.cuda }}
+        uses: N-Storm/cuda-toolkit@v0.2.28
+        id: cuda-toolkit
+        with:
+          cuda: "${{ matrix.cuda }}"
+          use-github-cache: false
+
+      - name: Install the latest version of uv and set the python version
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ matrix.pyver }}
+          activate-environment: true
+          enable-cache: true
+
+      - name: Install Dependencies
+        run: |
+          git config --system core.longpaths true
+          uv pip install --upgrade build setuptools wheel packaging
+
+      - name: Build Wheel
+        run: |
+          $cudaVersion = $env:CUDAVER.Remove($env:CUDAVER.LastIndexOf('.')).Replace('.','')
+          $env:CUDA_HOME = $env:CUDA_PATH
+          $env:CUDA_TOOLKIT_ROOT_DIR = $env:CUDA_PATH
+          $env:VERBOSE = '1'
+          # CUDA 12.1 supports up to compute capability 90 (Hopper)
+          $env:CMAKE_ARGS = '-DGGML_CUDA=on -DCMAKE_CUDA_ARCHITECTURES=' + $env:CUDAARCHVER + ' -DCMAKE_BUILD_PARALLEL_LEVEL=' + $env:MAX_JOBS
+          $env:CMAKE_ARGS = "-DGGML_CUDA_FORCE_MMQ=on -DCUDA_SEPARABLE_COMPILATION=on $env:CMAKE_ARGS"
+          $env:CMAKE_ARGS = "-DENABLE_CCACHE=on -DLLAMA_CURL=off -DLLAMA_HTTPLIB=on $env:CMAKE_ARGS"
+
+          # Basic options for compiling without AVX instructions
+          if ($env:AVXVER -eq 'Basic') {
+           $env:CMAKE_ARGS = $env:CMAKE_ARGS + ' -DGGML_AVX=off -DGGML_AVX2=off -DGGML_AVX512=off -DGGML_FMA=off -DGGML_F16C=off'
+          }
+          python -m build --wheel
+
+          if (!(Test-Path '.\dist\*.whl')) {
+            Write-Error "No wheel built in dist/ directory"
+            exit 1
+          }
+
+          Write-Output "CUDA_VERSION=$cudaVersion" >> $env:GITHUB_ENV
+
+          $wheel = (gi '.\dist\*.whl')[0]
+          $tagVer = $wheel.name.split('-')[1]
+          Write-Output "TAG_VERSION=$tagVer" >> $env:GITHUB_ENV
+
+      - name: Get Current Date
+        id: get-date
+        run: |
+          $currentDate = Get-Date -UFormat "%Y%m%d"
+          Write-Output "BUILD_DATE=$currentDate" >> $env:GITHUB_ENV
+
+      - name: Create Release
+        if: always() && env.TAG_VERSION != ''
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          tag_name: v${{ env.TAG_VERSION }}-cu${{ env.CUDA_VERSION }}-${{ env.AVXVER }}-win-${{ env.BUILD_DATE }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-wheels-cu121-win.yml
+++ b/.github/workflows/build-wheels-cu121-win.yml
@@ -1,0 +1,108 @@
+name: Build Wheels (CU121) for Windows
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build_wheels:
+    name: Build Wheel ${{ matrix.os }} ${{ matrix.pyver }} ${{ matrix.cuda }} ${{ matrix.releasetag }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['windows-2019']  # CUDA 12.1 requires older MSVC (< 14.40)
+        pyver: ["3.10", "3.11", "3.12", "3.13"]
+        cuda: ["12.1.1"]
+        releasetag: ["AVX2"]
+        cudaarch: ["all"]
+    defaults:
+      run:
+        shell: pwsh
+    env:
+      CUDAVER: ${{ matrix.cuda }}
+      AVXVER: ${{ matrix.releasetag }}
+      CUDAARCHVER: ${{ matrix.cudaarch }}
+      MAX_JOBS: 8
+
+    steps:
+      - name: Add MSBuild to PATH
+        if: runner.os == 'Windows'
+        uses: microsoft/setup-msbuild@v2
+        with:
+          msbuild-architecture: x64
+
+      - uses: actions/checkout@v5
+        with:
+          submodules: "recursive"
+
+      - name: Install CUDA ${{ matrix.cuda }}
+        uses: N-Storm/cuda-toolkit@v0.2.28
+        id: cuda-toolkit
+        with:
+          cuda: "${{ matrix.cuda }}"
+          use-github-cache: false
+
+      - name: Install the latest version of uv and set the python version
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ matrix.pyver }}
+          activate-environment: true
+          enable-cache: true
+
+      - name: Install Dependencies
+        run: |
+          git config --system core.longpaths true
+          uv pip install --upgrade build setuptools wheel packaging
+
+      - name: Build Wheel
+        run: |
+          $cudaVersion = $env:CUDAVER.Remove($env:CUDAVER.LastIndexOf('.')).Replace('.','')
+          $env:CUDA_HOME = $env:CUDA_PATH
+          $env:CUDA_TOOLKIT_ROOT_DIR = $env:CUDA_PATH
+          $env:VERBOSE = '1'
+          # CUDA 12.1 supports up to compute capability 90 (Hopper)
+          $env:CMAKE_ARGS = '-DGGML_CUDA=on -DCMAKE_CUDA_ARCHITECTURES=' + $env:CUDAARCHVER + ' -DCMAKE_BUILD_PARALLEL_LEVEL=' + $env:MAX_JOBS
+          $env:CMAKE_ARGS = "-DGGML_CUDA_FORCE_MMQ=on -DCUDA_SEPARABLE_COMPILATION=on $env:CMAKE_ARGS"
+          $env:CMAKE_ARGS = "-DENABLE_CCACHE=on -DLLAMA_CURL=off -DLLAMA_HTTPLIB=on $env:CMAKE_ARGS"
+
+          if ($env:AVXVER -eq 'AVX') {
+            $env:CMAKE_ARGS = $env:CMAKE_ARGS + ' -DGGML_AVX=on -DGGML_AVX2=off -DGGML_AVX512=off -DGGML_FMA=off -DGGML_F16C=off'
+          }
+          if ($env:AVXVER -eq 'AVX2') {
+            $env:CMAKE_ARGS = $env:CMAKE_ARGS + ' -DGGML_AVX=on -DGGML_AVX2=on -DGGML_AVX512=off'
+          }
+          if ($env:AVXVER -eq 'AVXVNNI') {
+           $env:CMAKE_ARGS = $env:CMAKE_ARGS + '  -DGGML_AVX=on -DGGML_AVX2=on -DGGML_AVX_VNNI=on'
+          }
+          if ($env:AVXVER -eq 'Basic') {
+           $env:CMAKE_ARGS = $env:CMAKE_ARGS + ' -DGGML_AVX=off -DGGML_AVX2=off -DGGML_AVX512=off -DGGML_FMA=off -DGGML_F16C=off'
+          }
+          python -m build --wheel
+
+          if (!(Test-Path '.\dist\*.whl')) {
+            Write-Error "No wheel built in dist/ directory"
+            exit 1
+          }
+
+          Write-Output "CUDA_VERSION=$cudaVersion" >> $env:GITHUB_ENV
+
+          $wheel = (gi '.\dist\*.whl')[0]
+          $tagVer = $wheel.name.split('-')[1]
+          Write-Output "TAG_VERSION=$tagVer" >> $env:GITHUB_ENV
+
+      - name: Get Current Date
+        id: get-date
+        run: |
+          $currentDate = Get-Date -UFormat "%Y%m%d"
+          Write-Output "BUILD_DATE=$currentDate" >> $env:GITHUB_ENV
+
+      - name: Create Release
+        if: always() && env.TAG_VERSION != ''
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          tag_name: v${{ env.TAG_VERSION }}-cu${{ env.CUDA_VERSION }}-${{ env.AVXVER }}-win-${{ env.BUILD_DATE }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add GitHub Actions workflows for building CUDA 12.1 wheels on Linux and Windows. Uses `windows-2019` runner to avoid MSVC 14.40+ compatibility issues with CUDA 12.1

## New Workflow Files
- `build-wheels-cu121-linux.yml` - Linux builds with AVX2
- `build-wheels-cu121-linux-basic.yml` - Linux builds without AVX instructions
- `build-wheels-cu121-win.yml` - Windows builds with AVX2
- `build-wheels-cu121-win-basic.yml` - Windows builds without AVX instructions

