### PR TITLE
[Fix] Search system paths for shared libraries

### DIFF
--- a/llama_cpp/_ctypes_extensions.py
+++ b/llama_cpp/_ctypes_extensions.py
@@ -101,7 +101,7 @@ def load_shared_library(lib_base_name: str, base_paths: Union[pathlib.Path, list
         try:
             return ctypes.CDLL(lib_path, **cdll_args)
         except Exception as e:
-            pass
+            errors.append(f"{lib_path}: {e}")
 
     # Then fallback to manually checking the list of paths.
     for base_path in base_paths:


### PR DESCRIPTION
This PR implements using [`ctypes.util.find_library`](https://docs.python.org/3/library/ctypes.html#finding-shared-libraries) to find the shared library paths while still falling back to the manual path searching logic.

This improves support for libraries which are installed into standard locations, or which appropriately install themselves with the correct linker targets. 

Closes #63