### PR TITLE
Fix AttributeError in llama_cache.py when calling longest_token_prefix

### DIFF
--- a/llama_cpp/llama_cache.py
+++ b/llama_cpp/llama_cache.py
@@ -15,6 +15,7 @@ from typing import (
 )
 
 import llama_cpp.llama
+import llama_cpp.llama as llama_module
 import llama_cpp._internals as _internals
 import llama_cpp.llama_cpp as llama_cpp
 
@@ -73,7 +74,7 @@ class LlamaDiskCache(BaseLlamaCache):
         min_len = 0
         min_key: Optional[Tuple[int, ...]] = None
         for k in self.cache.iterkeys():  # type: ignore
-            prefix_len = llama_cpp.llama.Llama.longest_token_prefix(k, key)
+            prefix_len = llama_module.Llama.longest_token_prefix(k, key)
             if prefix_len > min_len:
                 min_len = prefix_len
                 min_key = k  # type: ignore
@@ -128,7 +129,7 @@ class LlamaRAMCache(BaseLlamaCache):
         min_len = 0
         min_key = None
         keys = (
-            (k, llama_cpp.llama.Llama.longest_token_prefix(k, key))
+            (k, llama_module.Llama.longest_token_prefix(k, key))
             for k in self.cache_state.keys()
         )
         for k, prefix_len in keys:


### PR DESCRIPTION
## Summary

The following error occurs in `llama_cache.py`.

```
AttributeError: module 'llama_cpp.llama_cpp' has no attribute 'llama'
```

This seems to happen because `llama_cpp.llama_cpp` is imported using the name `llama_cpp`.
As a result, references to the Python wrapper module `llama_cpp.llama` (such as `llama_cpp.llama`) become invalid.

This PR keeps the change minimal.
To avoid this reference conflict, I import `llama_cpp.llama` under a different name and use that alias instead.

---

## Steps to Reproduce

I reproduced the problem under the following conditions.

1. Start ComfyUI
2. Run a workflow that includes a custom node using `LlamaDiskCache`
3. The first run completes successfully
4. Change only the **User prompt** and run the same workflow again
5. Immediately after generation starts on the second run, the following error occurs

```
AttributeError: module 'llama_cpp.llama_cpp' has no attribute 'llama'
```

Reproducibility:

```
Reproduced 3/3 times.
```

---

## Execution Log (excerpt)

First run

```
[LLM Session Chat] KV state: MISS (no state)
Hello! How can I assist you today? 😊
[LLM Session Chat] Generation attempt 1 succeeded
[LLM Session Chat] KV state: SAVED (memory)
```

Second run

```
[LLM Session Chat] Generation attempt 1 failed:
module 'llama_cpp.llama_cpp' has no attribute 'llama'
```

Traceback:

```
File ".../site-packages/llama_cpp/llama_cache.py", line 76, in _find_longest_prefix_key
    prefix_len = llama_cpp.llama.Llama.longest_token_prefix(k, key)
AttributeError: module 'llama_cpp.llama_cpp' has no attribute 'llama'
```

---

## Cause

In `llama_cache.py`, the following import exists:

```
import llama_cpp.llama_cpp as llama_cpp
```

Because of this alias, `llama_cpp` refers to `llama_cpp.llama_cpp`.

Later in the file the following reference is used:

```
llama_cpp.llama.Llama.longest_token_prefix(...)
```

This ends up trying to access a non-existent path like `llama_cpp.llama_cpp.llama`,
which leads to the `AttributeError`.

---

## Fix

The fix imports the Python wrapper module `llama_cpp.llama` under a different alias and use it only where `Llama.longest_token_prefix` is required.

I tried to keep the change minimal so the existing `llama_cpp` alias remains unchanged.

### Patch

```diff
@@ -15,6 +15,7 @@ from typing import (
 )

 import llama_cpp.llama
+import llama_cpp.llama as llama_module
 import llama_cpp._internals as _internals
 import llama_cpp.llama_cpp as llama_cpp

@@ -73,7 +74,7 @@ class LlamaDiskCache(BaseLlamaCache):
         min_len = 0
         min_key: Optional[Tuple[int, ...]] = None
         for k in self.cache.iterkeys():  # type: ignore
-            prefix_len = llama_cpp.llama.Llama.longest_token_prefix(k, key)
+            prefix_len = llama_module.Llama.longest_token_prefix(k, key)
             if prefix_len > min_len:
                 min_len = prefix_len
                 min_key = k  # type: ignore
@@ -128,7 +129,7 @@ class LlamaRAMCache(BaseLlamaCache):
         min_len = 0
         min_key = None
         keys = (
-            (k, llama_cpp.llama.Llama.longest_token_prefix(k, key))
+            (k, llama_module.Llama.longest_token_prefix(k, key))
             for k in self.cache_state.keys()
         )
         for k, prefix_len in keys:
```

---

## Environment

OS

```
Windows 10 (10.0.26200)
```

Python

```
3.10.11
```

llama-cpp-python (JamePeng fork)

```
version: 0.3.32
commit: e7e1d48
```

ComfyUI

```
commit: 8f40b43e0204d5b9780f3e9618e140e929e80594
```

Let me know if any additional information would be helpful.